### PR TITLE
Arbitrum network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sarcophagus-org/sarcophagus-v2-sdk-client",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "main": "dist/browser.js",
   "browser": "dist/browser.js",
   "type": "module",

--- a/src/networkConfig/index.ts
+++ b/src/networkConfig/index.ts
@@ -16,6 +16,8 @@ export const POLYGON_MUMBAI_CHAIN_ID = 80001;
 export const POLYGON_MAINNET_CHAIN_ID = 137;
 export const HARDHAT_CHAIN_ID = 31337;
 
+export const ARBITRUM_CHAIN_ID = 42161;
+
 /**
  * A map of supported chain IDs to their network names
  */
@@ -26,6 +28,7 @@ export const SARCO_SUPPORTED_NETWORKS: Map<number, string> = new Map([
   [BASE_GOERLI_CHAIN_ID, 'baseGoerli'],
   [POLYGON_MUMBAI_CHAIN_ID, 'polygonMumbai'],
   [POLYGON_MAINNET_CHAIN_ID, 'polygonMainnet'],
+  [ARBITRUM_CHAIN_ID, 'arbitrum']
 ]);
 
 export const hardhatNetworkConfig = (override?: {
@@ -97,10 +100,35 @@ export const polygonMainnetNetworkConfig = (config?: {
     nodeUrl: 'https://node1.irys.xyz',
   },
   arweaveConfig,
-  subgraphUrl: 'https://subgraph.satsuma-prod.com/62645f651f37/seths-personal--297874/polygon/api',
+  subgraphUrl: 'https://subgraph.satsuma-prod.com/556ca65949fe/sarcophagus/polygon/api',
   zeroExApiKey: config?.zeroExApiKey ?? '',
   zeroExApiUrl: 'https://polygon.api.0x.org',
   zeroExSellToken: 'MATIC',
+  apiUrlBase: 'https://api.encryptafile.com',
+});
+
+export const arbitrumNetworkConfig = (config?: {
+  arbiscanApiKey?: string;
+  zeroExApiKey?: string;
+}): SarcoNetworkConfig => ({
+  chainId: POLYGON_MUMBAI_CHAIN_ID,
+  networkName: 'Arbitrum One',
+  networkShortName: 'arbitrum',
+  tokenSymbol: 'ETH',
+  sarcoTokenAddress: '0x82155Ab6b6c1113CFb352c7573B010a88f5974bD',
+  diamondDeployAddress: '0xc1984df3e3ddc1DC24d54179CCD5537e290C7E9c',
+  etherscanApiUrl: 'https://api.arbiscan.io/api',
+  etherscanApiKey: config?.arbiscanApiKey ?? '',
+  explorerUrl: 'https://arbiscan.io/',
+  bundlr: {
+    currencyName: 'ethereum',
+    nodeUrl: 'https://devnet.irys.xyz',
+  },
+  arweaveConfig,
+  subgraphUrl: 'https://subgraph.satsuma-prod.com/556ca65949fe/sarcophagus/arbitrum/api',
+  zeroExApiKey: config?.zeroExApiKey ?? '',
+  zeroExApiUrl: 'https://arbitrum.api.0x.org',
+  zeroExSellToken: 'ETH',
   apiUrlBase: 'https://api.encryptafile.com',
 });
 


### PR DESCRIPTION
Add arbitrum network config.

Update polygon mainnet subgraph url to use alchemy's indexer instead of the graph.